### PR TITLE
WDB-Optimistic-Lock-For-VaidasJ

### DIFF
--- a/backend/BusinessLogic/Services/VideoService/VideoService.cs
+++ b/backend/BusinessLogic/Services/VideoService/VideoService.cs
@@ -215,7 +215,7 @@ namespace BusinessLogic.Services.VideoService
 
         public async Task MarkVideoForDeletion(Video video)
         {
-            video.DeleteDate = DateTime.Today.AddMonths(1);
+            video.DeleteDate = DateTime.Today;
             await _videosRepository.Save();
         }
 

--- a/backend/DataAccess/EntityConfigurations/VideoEntityConfiguration.cs
+++ b/backend/DataAccess/EntityConfigurations/VideoEntityConfiguration.cs
@@ -23,6 +23,7 @@ namespace DataAccess.EntityConfigurations
             builder.Property(c => c.Format);
             builder.Property(c => c.UploadDate);
             builder.Property(c => c.DeleteDate);
+            builder.Property(c => c.RowVersion);
 
             builder.HasOne(c => c.User)
                 .WithMany(c => c.Videos)

--- a/backend/DataAccess/Models/Video.cs
+++ b/backend/DataAccess/Models/Video.cs
@@ -34,5 +34,7 @@ namespace DataAccess.Models
         [Required]
         public Guid UserId { get; set; }
         public User User { get; set; }
+
+        [Timestamp] public byte[] RowVersion { get; set; }
     }
 }

--- a/backend/RestAPI/Controllers/VideosController.cs
+++ b/backend/RestAPI/Controllers/VideosController.cs
@@ -96,7 +96,8 @@ namespace RestAPI.Controllers
                 Duration = video.Duration,
                 Format = video.Format,
                 Height = video.Height,
-                Width = video.Width
+                Width = video.Width,
+                DeleteDate = video.DeleteDate?.ToString("yyyy-MM-dd")
             };
 
             return Ok(videoDto);

--- a/backend/RestAPI/Migrations/20210525144140_RowVersionVideo.Designer.cs
+++ b/backend/RestAPI/Migrations/20210525144140_RowVersionVideo.Designer.cs
@@ -4,14 +4,16 @@ using DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace RestAPI.Migrations
 {
     [DbContext(typeof(BackendContext))]
-    partial class BackendContextModelSnapshot : ModelSnapshot
+    [Migration("20210525144140_RowVersionVideo")]
+    partial class RowVersionVideo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/RestAPI/Migrations/20210525144140_RowVersionVideo.cs
+++ b/backend/RestAPI/Migrations/20210525144140_RowVersionVideo.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace RestAPI.Migrations
+{
+    public partial class RowVersionVideo : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Videos",
+                type: "rowversion",
+                rowVersion: true,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Videos");
+        }
+    }
+}

--- a/backend/RestAPI/Models/Responses/ConflictVideoDto.cs
+++ b/backend/RestAPI/Models/Responses/ConflictVideoDto.cs
@@ -1,0 +1,7 @@
+namespace RestAPI.Models.Responses
+{
+    public class ConflictVideoDto : VideoDto 
+    {
+        public string OldTitle { get; set; } 
+    }
+}

--- a/backend/RestAPI/Models/Responses/VideoDto.cs
+++ b/backend/RestAPI/Models/Responses/VideoDto.cs
@@ -8,6 +8,7 @@ namespace RestAPI.Models.Responses
         public long Size { get; set; }
         public string Title { get; set; }
         public string UploadDate { get; set; }
+        public string RowVersion { get; set; }
 
     }
 }

--- a/backend/RestAPI/Models/Responses/VideoDto.cs
+++ b/backend/RestAPI/Models/Responses/VideoDto.cs
@@ -9,6 +9,5 @@ namespace RestAPI.Models.Responses
         public string Title { get; set; }
         public string UploadDate { get; set; }
         public string RowVersion { get; set; }
-
     }
 }

--- a/backend/RestAPI/Models/Responses/VideoInformationDto.cs
+++ b/backend/RestAPI/Models/Responses/VideoInformationDto.cs
@@ -15,5 +15,6 @@ namespace RestAPI.Models.Responses
         public int Duration { get; set; }
         public string Format { get; set; }
         public string UploadDate { get; set; }
+        public string DeleteDate { get; set; }
     }
 }

--- a/backend/RestAPI/Models/Responses/VideoInformationDto.cs
+++ b/backend/RestAPI/Models/Responses/VideoInformationDto.cs
@@ -16,5 +16,6 @@ namespace RestAPI.Models.Responses
         public string Format { get; set; }
         public string UploadDate { get; set; }
         public string DeleteDate { get; set; }
+        public string RowVersion { get; set; }
     }
 }

--- a/frontend/src/api/VideoAPI.js
+++ b/frontend/src/api/VideoAPI.js
@@ -19,24 +19,26 @@ export const uploadChunk = async (
     cancelToken: cancelTokenSource.token,
   });
 
-export const finishUpload = async (videoFileName, cancelTokenSource) =>
+export const finishUpload = (videoFileName, cancelTokenSource) =>
   Api.post('/Videos/UploadComplete', null, {
     params: { fileName: videoFileName },
     cancelToken: cancelTokenSource.token,
   });
 
-export const deleteChunks = async (videoFileName) =>
+export const deleteChunks = (videoFileName) =>
   Api.delete('/Videos/DeleteChunks', {
     params: { fileName: videoFileName },
   });
 
-export const changeTitle = async (videoId, newTitle) =>
-  Api.patch('/Videos/title', null, { params: { id: videoId, newTitle } });
+export const changeTitle = (videoId, newTitle, rowVersion) =>
+  Api.patch('/Videos/title', null, {
+    params: { id: videoId, newTitle, rowVersion },
+  });
 
-export const deleteVideos = async (videoIds) =>
+export const deleteVideos = (videoIds) =>
   Api.delete(`/Videos`, { data: videoIds });
 
-export const markForDeletion = async (videoIds) =>
+export const markForDeletion = (videoIds) =>
   Api.patch('/Videos/markForDeletion', videoIds);
 
 export const getVideoDetails = (videoId) =>

--- a/frontend/src/components/InformationDrawer/InformationDrawer.js
+++ b/frontend/src/components/InformationDrawer/InformationDrawer.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { debounce } from 'lodash';
 import {
   List,
@@ -15,15 +15,15 @@ export default function InformationDrawer({
   open,
   onOpen,
   onClose,
-  videoTitle = '',
   videoDuration = '',
   videoSize = '',
   videoResolution = '',
   videoFormat = '',
   onVideoTitleChange,
+  title,
+  setTitle,
+  disableTextField,
 }) {
-  const [title, setTitle] = useState(videoTitle);
-
   const handleTitleChange = (newTitle) => {
     onVideoTitleChange(newTitle);
   };
@@ -76,6 +76,7 @@ export default function InformationDrawer({
         onChange={delayedHandleTitleChange}
         variant="outlined"
         style={{ width: '100%' }}
+        disabled={disableTextField}
       />
     </ListItem>
   );

--- a/frontend/src/components/InformationDrawer/InformationDrawer.js
+++ b/frontend/src/components/InformationDrawer/InformationDrawer.js
@@ -19,9 +19,9 @@ export default function InformationDrawer({
   videoSize = '',
   videoResolution = '',
   videoFormat = '',
-  onVideoTitleChange,
+  onVideoTitleChange, // for changes in BE
   title,
-  setTitle,
+  setTitle, // for textfield
   disableTextField,
 }) {
   const handleTitleChange = (newTitle) => {

--- a/frontend/src/components/OverwriteTitleDialog/OverwriteTitleDialog.js
+++ b/frontend/src/components/OverwriteTitleDialog/OverwriteTitleDialog.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from '@material-ui/core';
+
+export default function OverwriteTitleDialog({
+  open,
+  onConfirm,
+  onCancel,
+  oldTitle,
+  newTitle,
+}) {
+  return (
+    <Dialog disableBackdropClick disableEscapeKeyDown maxWidth="xs" open={open}>
+      <DialogTitle>The title has been changed recently</DialogTitle>
+      <DialogContent>
+        <Typography>
+          Newest title is <b>{oldTitle}</b>
+          <br />
+          Do you want to overwrite it with <b>{newTitle}</b>?
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button autoFocus onClick={onCancel} color="primary">
+          No
+        </Button>
+        <Button onClick={onConfirm} color="primary">
+          Yes
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/UploadModal/UploadModal.js
+++ b/frontend/src/components/UploadModal/UploadModal.js
@@ -221,12 +221,13 @@ export default function UploadModal({ show, onClose }) {
     }
   };
 
-  const handleVideoTitleChange = (videoId) => (newTitle) => {
+  const handleVideoTitleChange = (videoId) => (newTitle, rowVersion) => {
     if (newTitle === '') {
       setAreTitlesMissing(true);
       return;
     }
-    changeTitle(videoId, newTitle)
+    console.log(rowVersion);
+    changeTitle(videoId, newTitle, rowVersion)
       .then((response) => {
         const index = uploadedVideos.current.findIndex(
           (video) => video.id === videoId,
@@ -236,6 +237,7 @@ export default function UploadModal({ show, onClose }) {
         uploadedVideos.current = [...uploadedVideosCopy];
         setAreTitlesMissing(false);
         forceUpdate();
+        console.log(response.data);
       })
       .catch(() => setShowSnackbar({ ...showSnackbar, serverError: false }));
   };

--- a/frontend/src/components/UploadModal/UploadedVideoListItem.js
+++ b/frontend/src/components/UploadModal/UploadedVideoListItem.js
@@ -1,21 +1,30 @@
 import React, { useState, useCallback } from 'react';
 import { debounce } from 'lodash';
 import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
-import { Grid, TextField, InputAdornment, ListItem, IconButton } from '@material-ui/core';
+import {
+  Grid,
+  TextField,
+  InputAdornment,
+  ListItem,
+  IconButton,
+} from '@material-ui/core';
 import { formatBytesToString } from '../../util';
 
 export default function UploadedVideoListItem({
   video,
   onVideoTitleChange,
-  onVideoDeletion
+  onVideoDeletion,
 }) {
-  const [ title, setTitle ] = useState(video.title);
+  const [title, setTitle] = useState(video.title);
 
   const handleTitleChange = (newTitle) => {
-    onVideoTitleChange(newTitle);
+    onVideoTitleChange(newTitle, video.rowVersion);
   };
 
-  const debouncedHandleTitleChange = useCallback(debounce(handleTitleChange, 500), []);
+  const debouncedHandleTitleChange = useCallback(
+    debounce(handleTitleChange, 500),
+    [],
+  );
 
   const delayedHandleTitleChange = (event) => {
     const newTitle = event.target.value;
@@ -29,9 +38,9 @@ export default function UploadedVideoListItem({
     <ListItem key={video.id}>
       <Grid
         container
-        direction='row'
-        alignItems='center'
-        justify='space-evenly'
+        direction="row"
+        alignItems="center"
+        justify="space-evenly"
       >
         <Grid item xs>
           <TextField
@@ -46,7 +55,6 @@ export default function UploadedVideoListItem({
               endAdornment: (
                 <InputAdornment position="end">
                   {formatBytesToString(video.size)}
-                    
                 </InputAdornment>
               ),
             }}

--- a/frontend/src/components/UploadModal/UploadedVideoListItem.js
+++ b/frontend/src/components/UploadModal/UploadedVideoListItem.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { debounce } from 'lodash';
 import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
 import {
@@ -12,13 +12,13 @@ import { formatBytesToString } from '../../util';
 
 export default function UploadedVideoListItem({
   video,
-  onVideoTitleChange,
+  title,
+  onVideoTitleTextFieldChange,
+  onVideoTitleChange, // for changes in BE
   onVideoDeletion,
 }) {
-  const [title, setTitle] = useState(video.title);
-
   const handleTitleChange = (newTitle) => {
-    onVideoTitleChange(newTitle, video.rowVersion);
+    onVideoTitleChange(newTitle);
   };
 
   const debouncedHandleTitleChange = useCallback(
@@ -28,7 +28,7 @@ export default function UploadedVideoListItem({
 
   const delayedHandleTitleChange = (event) => {
     const newTitle = event.target.value;
-    setTitle(newTitle);
+    onVideoTitleTextFieldChange(newTitle);
 
     debouncedHandleTitleChange.cancel();
     debouncedHandleTitleChange(newTitle);

--- a/frontend/src/components/UploadModal/VideosList.js
+++ b/frontend/src/components/UploadModal/VideosList.js
@@ -11,6 +11,8 @@ export default function VideosList({
   uploadProgress,
   onUploadCancel,
   uploadedVideos,
+  videoTitles,
+  onVideoTitleTextFieldChange,
   onVideoTitleChange,
   onVideoDeletion,
 }) {
@@ -44,11 +46,12 @@ export default function VideosList({
 
   const renderUploadedVideosListItems = () => {
     if (uploadedVideos.length > 0) {
-      console.log(uploadedVideos);
-      return uploadedVideos.map((video) => (
+      return uploadedVideos.map((video, index) => (
         <UploadedVideoListItem
           key={video.id}
           video={video}
+          title={videoTitles[index]}
+          onVideoTitleTextFieldChange={onVideoTitleTextFieldChange(video.id)}
           onVideoTitleChange={onVideoTitleChange(video.id)}
           onVideoDeletion={onVideoDeletion(video.id)}
         />

--- a/frontend/src/components/UploadModal/VideosList.js
+++ b/frontend/src/components/UploadModal/VideosList.js
@@ -12,7 +12,7 @@ export default function VideosList({
   onUploadCancel,
   uploadedVideos,
   onVideoTitleChange,
-  onVideoDeletion
+  onVideoDeletion,
 }) {
   const renderVideosToUploadListItems = () => {
     if (videosToUploadNames.length > 0) {
@@ -30,19 +30,22 @@ export default function VideosList({
 
   const renderInUploadVideoListItem = () => {
     if (inUploadVideoName !== undefined) {
-      return <InUploadVideoListItem
-        key={inUploadVideoName}
-        videoName={inUploadVideoName}
-        progress={uploadProgress}
-        onUploadCancel={onUploadCancel}
-      />
+      return (
+        <InUploadVideoListItem
+          key={inUploadVideoName}
+          videoName={inUploadVideoName}
+          progress={uploadProgress}
+          onUploadCancel={onUploadCancel}
+        />
+      );
     }
     return null;
   };
 
   const renderUploadedVideosListItems = () => {
     if (uploadedVideos.length > 0) {
-      return uploadedVideos.map(video => (
+      console.log(uploadedVideos);
+      return uploadedVideos.map((video) => (
         <UploadedVideoListItem
           key={video.id}
           video={video}

--- a/frontend/src/components/VideoCard/VideoCard.js
+++ b/frontend/src/components/VideoCard/VideoCard.js
@@ -24,9 +24,7 @@ const VideoCard = ({ title, onSelect, id, isSelected }) => {
   }, []);
 
   const handleClick = () => {
-    history.push(`/player/${id}`, {
-      isFromBin: window.location.pathname.includes('bin'),
-    });
+    history.push(`/player/${id}`);
   };
 
   return (

--- a/frontend/src/containers/PlayerPage/PlayerPage.js
+++ b/frontend/src/containers/PlayerPage/PlayerPage.js
@@ -68,15 +68,16 @@ class PlayerPage extends React.Component {
     const size = formatBytesToString(source.size);
     const resolution = `${source.width}x${source.height}`;
     const duration = secondsToHms(source.duration);
-    const output = {
+    const isFromBin = !!source?.deleteDate;
+    return {
       id: source.id,
       title: source.title,
       format: source.format,
       duration,
       resolution,
       size,
+      isFromBin,
     };
-    return output;
   };
 
   updateWindowDimensions = () =>
@@ -156,7 +157,6 @@ class PlayerPage extends React.Component {
       showVideoRestorationError,
     } = this.state;
     const { location } = this.props;
-    const { isFromBin } = location.state;
 
     // This fallback height is needed, since TopBar is not rendered until video information is fetched, so ref will be null
     const fallBackTopBarHeight = screenWidth > 600 ? 64 : 56; // These values are from Material UI AppBar source code
@@ -242,12 +242,12 @@ class PlayerPage extends React.Component {
             <DeleteConfirmationDialog
               open={showDeletionDialog}
               onConfirm={
-                isFromBin
+                video.isFromBin
                   ? this.handleVideoDeletion
                   : this.handleVideoMarkForDeletion
               }
               onCancel={this.toggleDeletionDialog}
-              deleteForever={isFromBin}
+              deleteForever={video.isFromBin}
             />
             {showDeletionError && (
               <CustomSnackbar
@@ -271,7 +271,7 @@ class PlayerPage extends React.Component {
                 title={video.title}
                 showArrow
                 onIconsClick={
-                  !isFromBin
+                  !video.isFromBin
                     ? [
                         this.toggleInformationDrawer,
                         handleVideoDownload,
@@ -285,7 +285,7 @@ class PlayerPage extends React.Component {
                 }
                 onActionIconClick={this.handleArrowBackClick}
                 iconsToShow={
-                  !isFromBin
+                  !video.isFromBin
                     ? [InfoIcon, DownloadIcon, DeleteIcon]
                     : [InfoIcon, RestoreIcon, DeleteForeverIcon]
                 }

--- a/frontend/src/containers/PlayerPage/PlayerPage.js
+++ b/frontend/src/containers/PlayerPage/PlayerPage.js
@@ -23,6 +23,7 @@ import CustomSnackbar from '../../components/CustomSnackbar/CustomSnackbar';
 import DeleteConfirmationDialog from '../../components/DeleteConfirmationDialog/DeleteConfirmationDialog';
 import InformationDrawer from '../../components/InformationDrawer/InformationDrawer';
 import { formatBytesToString, secondsToHms } from '../../util';
+import OverwriteTitleDialog from '../../components/OverwriteTitleDialog/OverwriteTitleDialog';
 
 class PlayerPage extends React.Component {
   constructor(props) {
@@ -40,6 +41,10 @@ class PlayerPage extends React.Component {
       showDeletionError: false,
       showInformationDrawer: false,
       showVideoRestorationError: false,
+      showChangeTitleError: false,
+      showChangeTitleConflict: false,
+      oldTitle: '',
+      informationDrawerTitle: '',
     };
     this.topBarRef = React.createRef();
   }
@@ -55,7 +60,7 @@ class PlayerPage extends React.Component {
         const url = `http://localhost:61346/api/Videos/stream?videoId=${videoId}&token=${token}`;
 
         const video = this.transformVideo(response.data);
-        this.setState({ url, video });
+        this.setState({ url, video, informationDrawerTitle: video.title });
       })
       .catch(() => this.setState({ showPlaybackError: true }));
   }
@@ -77,6 +82,7 @@ class PlayerPage extends React.Component {
       resolution,
       size,
       isFromBin,
+      rowVersion: source.rowVersion,
     };
   };
 
@@ -92,10 +98,34 @@ class PlayerPage extends React.Component {
   };
 
   handleVideoTitleChange = (title) => {
-    changeTitle(video.id, title).then(() => {
-      video.title = title;
-      this.setState({ video });
-    });
+    const { video } = this.state;
+    this.setState({ showChangeTitleError: false });
+    this.setState({ showChangeTitleConflict: false });
+    changeTitle(video.id, title, video.rowVersion)
+      .then(({ data }) => {
+        video.title = data.title;
+        video.rowVersion = data.rowVersion;
+        this.setState({ video });
+      })
+      .catch((error) => {
+        if (error === undefined) {
+          this.setState({ showChangeTitleError: true });
+        }
+        if (error.response.status === 409) {
+          const { data } = error.response;
+          video.title = data.title;
+          video.rowVersion = data.rowVersion;
+          this.setState({
+            oldTitle: data.oldTitle,
+            video,
+            showChangeTitleConflict: true,
+          });
+        }
+      });
+  };
+
+  handleInformationDrawerTitleChange = (newTitle) => {
+    this.setState({ informationDrawerTitle: newTitle });
   };
 
   handleVideoDownload = () => {
@@ -176,7 +206,7 @@ class PlayerPage extends React.Component {
     const {
       showDownloadError,
       showDownloadInProgress,
-      showDownloadSuccess
+      showDownloadSuccess,
     } = this.state;
 
     if (showDownloadError) {
@@ -208,6 +238,22 @@ class PlayerPage extends React.Component {
     return null;
   };
 
+  handleOverwriteTitleDialogCancel = () => {
+    const { video, oldTitle } = this.state;
+    video.title = oldTitle;
+    this.setState({
+      showChangeTitleConflict: false,
+      video,
+      informationDrawerTitle: oldTitle,
+    });
+  };
+
+  handleOverwriteTitleDialogConfirm = () => {
+    const { informationDrawerTitle } = this.state;
+    this.setState({ showChangeTitleConflict: false });
+    this.handleVideoTitleChange(informationDrawerTitle);
+  };
+
   render() {
     const {
       url,
@@ -219,8 +265,11 @@ class PlayerPage extends React.Component {
       showDeletionError,
       showInformationDrawer,
       showVideoRestorationError,
+      showChangeTitleError,
+      showChangeTitleConflict,
+      oldTitle,
+      informationDrawerTitle,
     } = this.state;
-    const { location } = this.props;
 
     // This fallback height is needed, since TopBar is not rendered until video information is fetched, so ref will be null
     const fallBackTopBarHeight = screenWidth > 600 ? 64 : 56; // These values are from Material UI AppBar source code
@@ -231,6 +280,13 @@ class PlayerPage extends React.Component {
 
     return (
       <div className="root">
+        <OverwriteTitleDialog
+          open={showChangeTitleConflict}
+          oldTitle={oldTitle}
+          newTitle={video?.title}
+          onCancel={this.handleOverwriteTitleDialogCancel}
+          onConfirm={this.handleOverwriteTitleDialogConfirm}
+        />
         {video === undefined ? (
           showPlaybackError && (
             <CustomSnackbar
@@ -261,6 +317,13 @@ class PlayerPage extends React.Component {
               />
             )}
             {showVideoRestorationError && (
+              <CustomSnackbar
+                message="Oops... Something wrong happened, we could not restore your video"
+                onClose={this.hideDeletionError}
+                severity="error"
+              />
+            )}
+            {showChangeTitleError && (
               <CustomSnackbar
                 message="Oops... Something wrong happened, we could not restore your video"
                 onClose={this.hideDeletionError}
@@ -299,12 +362,14 @@ class PlayerPage extends React.Component {
               open={showInformationDrawer}
               onOpen={this.toggleInformationDrawer}
               onClose={this.toggleInformationDrawer}
-              videoTitle={video.title}
+              title={informationDrawerTitle}
+              setTitle={this.handleInformationDrawerTitleChange}
               videoDuration={video.duration}
               videoSize={video.size}
               videoFormat={video.format}
               videoResolution={video.resolution}
               onVideoTitleChange={this.handleVideoTitleChange}
+              disableTextField={showChangeTitleConflict}
             />
             <div className="player-wrapper">
               <ReactPlayer


### PR DESCRIPTION
The PR for Optimistic locking. It's huge. But what wouldn't we do for that 0.25 mark. Optimistic locking implemented by searching for different versions in requests

How it works:

Window A GET Entity 1 Version: 1
Window B GET Entity 1 Version: 1

Both versions are the same

Window A PATCH Entity 1 title Version 2
Window B PATCH Entity 1 title Version 1

... Conflict! The title has recently changed, do you want to overwrite?

This happened because Window B tried to update Entity 1 Version 1 while it was now Version 2

I hope that makes sense. Try changing the title in video information in two different windows. Have fun. Try to break it

PR includes: 
- Dialog box, for overwriting
- Checking for conflicts in backend "Title" endpoint
- Other minor stuff. This small thing needed a lot of readjustments in lots of places. Special thanks to @tmaciulis22 

